### PR TITLE
Added a line to Dockerfile to fix an external dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN \
   go get -v github.com/danderson/pixiecore/tftp && \
   go get -v github.com/coreos/etcd/client && \
   go get -v github.com/krolaw/dhcp4 &&\
-  go get -v github.com/gorilla/mux
+  go get -v github.com/gorilla/mux && \
+  go get -v github.com/elazarl/go-bindata-assetfs
 
 ENTRYPOINT ["/go/src/github.com/cafebazaar/aghajoon/aghajoon"]
 # ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
```
==> pxeserver:  /usr/local/go/src/github.com/elazarl/go-bindata-assetfs (from $GOROOT)
==> pxeserver:  /go/src/github.com/elazarl/go-bindata-assetfs (from $GOPATH)
==> pxeserver: 
==> pxeserver: The command '/bin/sh -c go build .' returned a non-zero code: 1
```

Adding a line to Docker file to "go get" that external dependency seems to fix the issue. 
