### PR TITLE
Added validation to cloud-config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN \
   go get -v github.com/coreos/etcd/client && \
   go get -v github.com/krolaw/dhcp4 &&\
   go get -v github.com/gorilla/mux && \
-  go get -v github.com/elazarl/go-bindata-assetfs
+  go get -v github.com/elazarl/go-bindata-assetfs && \
+  go get -v github.com/coreos/coreos-cloudinit
 
 ENTRYPOINT ["/go/src/github.com/cafebazaar/aghajoon/aghajoon"]
 # ENTRYPOINT ["/bin/bash"]

--- a/cloudconfig/validation.go
+++ b/cloudconfig/validation.go
@@ -1,0 +1,18 @@
+package cloudconfig
+
+import (
+	"bytes"
+	"github.com/coreos/coreos-cloudinit/config/validate"
+)
+
+func validateCloudConfig(config string) string {
+	var errors bytes.Buffer
+	errors.WriteString("\n")
+	validationReport, _ := validate.Validate([]byte(config))
+	for _, errorEntry := range validationReport.Entries() {
+		errors.WriteString("#")
+		errors.WriteString(errorEntry.String())
+		errors.WriteString("\n")
+	}
+	return errors.String()
+}


### PR DESCRIPTION
Cloud-config validation is done using the official coreos-cloudinit remote repository.

 -new: Added dependency to Dockerfile
 -new: Added calling switch to http.go
 -new: Added validation.go which makes the actual call to the third party validator
