### PR TITLE
Add an initial workspace upload support

### DIFF
--- a/datasource/etcd_datasource.go
+++ b/datasource/etcd_datasource.go
@@ -196,17 +196,6 @@ func NewEtcdDataSource(kapi etcd.KeysAPI, client etcd.Client, leaseStart net.IP,
 	leaseRange int, clusterName, workspacePath string, defaultNameServers []string,
 	selfInfo InstanceInfo) (DataSource, error) {
 
-	data, err := ioutil.ReadFile(filepath.Join(workspacePath, "initial.yaml"))
-	if err != nil {
-		return nil, fmt.Errorf("error while trying to read initial data: %s", err)
-	}
-
-	iVals := make(map[string]string)
-	err = yaml.Unmarshal(data, &iVals)
-	if err != nil {
-		return nil, fmt.Errorf("error while reading initial data: %s", err)
-	}
-
 	ds := &EtcdDataSource{
 		keysAPI:         kapi,
 		client:          client,
@@ -219,26 +208,7 @@ func NewEtcdDataSource(kapi etcd.KeysAPI, client etcd.Client, leaseStart net.IP,
 		selfInfo:        selfInfo,
 	}
 
-	for key, value := range iVals {
-		currentValue, _ := ds.GetClusterVariable(key)
-		if len(currentValue) == 0 {
-			err := ds.SetClusterVariable(key, value)
-
-			if err != nil {
-				return nil,
-					fmt.Errorf("error while setting initial value (%q: %q): %s",
-						key, value, err)
-			}
-
-			currentValue = value
-		}
-		log.WithFields(log.Fields{
-			"where":   "datasource.NewEtcdDataSource",
-			"action":  "debug",
-			"object":  "ClusterVariable",
-			"subject": key,
-		}).Debugf("%s=%q", key, value)
-	}
+	ds.FillEtcdFromWorkspace()
 
 	// TODO: Integrate DNS service into Blacksmith
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 3*time.Second)
@@ -259,10 +229,40 @@ func NewEtcdDataSource(kapi etcd.KeysAPI, client etcd.Client, leaseStart net.IP,
 	defer cancel4()
 	ds.keysAPI.Set(ctx4, "skydns/config", skydnsconfig, nil)
 
-	_, err = ds.MachineInterface(selfInfo.Nic).Machine(true, selfInfo.IP)
+	_, err := ds.MachineInterface(selfInfo.Nic).Machine(true, selfInfo.IP)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating the machine representation of self: %s", err)
 	}
 
 	return ds, nil
+}
+
+func (ds *EtcdDataSource) FillEtcdFromWorkspace() {
+	data, err := ioutil.ReadFile(filepath.Join(ds.workspacePath, "initial.yaml"))
+	if err != nil {
+		log.Info("datasource.fillEtcdFromWorkspace: initial.yaml was not avaiable to read, perhaps should be provided later")
+	}
+
+	iVals := make(map[string]string)
+	err = yaml.Unmarshal(data, &iVals)
+	if err != nil {
+		log.Errorf("error while reading initial data: %s", err)
+		return
+	}
+
+	for key, value := range iVals {
+		err := ds.SetClusterVariable(key, value)
+
+		if err != nil {
+			log.Errorf("error while setting initial value (%q: %q): %s", key, value, err)
+			return
+		}
+
+		log.WithFields(log.Fields{
+			"where":   "datasource.NewEtcdDataSource",
+			"action":  "debug",
+			"object":  "ClusterVariable",
+			"subject": key,
+		}).Debugf("%s=%q", key, value)
+	}
 }

--- a/datasource/structure.go
+++ b/datasource/structure.go
@@ -73,13 +73,14 @@ type MachineInterface interface {
 
 // InstanceInfo describes an active instance of blacksmith running on some machine
 type InstanceInfo struct {
-	IP               net.IP           `json:"ip"`
-	Nic              net.HardwareAddr `json:"nic"`
-	WebPort          int              `json:"webPort"`
-	Version          string           `json:"version"`
-	Commit           string           `json:"commit"`
-	BuildTime        string           `json:"buildTime"`
-	ServiceStartTime int64            `json:"serviceStartTime"`
+	IP                   net.IP           `json:"ip"`
+	Nic                  net.HardwareAddr `json:"nic"`
+	WebPort              int              `json:"webPort"`
+	Version              string           `json:"version"`
+	Commit               string           `json:"commit"`
+	BuildTime            string           `json:"buildTime"`
+	ServiceStartTime     int64            `json:"serviceStartTime"`
+	CurrentWorkspaceHash string           `json:"currentWorkspaceHash"`
 }
 
 // File describes a file located inside our workspace

--- a/dev_run.sh
+++ b/dev_run.sh
@@ -209,6 +209,24 @@ if [[ "${1:-}" == "clean" ]]; then
 fi
 
 
+
+#### upload workspace
+if [[ "${1:-}" == "upload-workspace" ]]; then
+    FILENAME=../blacksmith-kubernetes/workspace/files/workspace.tar
+    #gzip -k ../blacksmith-kubernetes/workspaces/current/files/workspace.tar
+
+    for i in $(seq $BOOTSTRAPPERS); do
+        MAC=$(vboxmanage showvminfo bootstrapper_$i --machinereadable | grep macaddress3 | sed 's/macaddress3="\(.*\)"/\1/g')
+        MAC=$(echo $MAC | sed -e 's/[0-9A-F]\{2\}/&:/g' -e 's/:$//')
+        IP=$(ip neighbor | grep -i "${MAC}" | cut -d" " -f1)
+        echo "Starting $IP"
+        ./workspace_upload.sh $IP $FILENAME
+    done
+    exit
+fi
+
+
+
 #### init bootstrappers etcd
 if [[ "${1:-}" == "init-bootstrappers" ]]; then
     for i in $(seq $BOOTSTRAPPERS); do

--- a/dev_run.sh
+++ b/dev_run.sh
@@ -209,22 +209,17 @@ if [[ "${1:-}" == "clean" ]]; then
 fi
 
 
-
 #### upload workspace
 if [[ "${1:-}" == "upload-workspace" ]]; then
-    FILENAME=../blacksmith-kubernetes/workspace/files/workspace.tar
-    #gzip -k ../blacksmith-kubernetes/workspaces/current/files/workspace.tar
-
     for i in $(seq $BOOTSTRAPPERS); do
         MAC=$(vboxmanage showvminfo bootstrapper_$i --machinereadable | grep macaddress3 | sed 's/macaddress3="\(.*\)"/\1/g')
         MAC=$(echo $MAC | sed -e 's/[0-9A-F]\{2\}/&:/g' -e 's/:$//')
         IP=$(ip neighbor | grep -i "${MAC}" | cut -d" " -f1)
         echo "Starting $IP"
-        ./workspace_upload.sh $IP $FILENAME
+        ./workspace-upload.sh $IP
     done
     exit
 fi
-
 
 
 #### init bootstrappers etcd
@@ -291,7 +286,9 @@ then
     createNetwork
     createBootstrappers
     initEtcd
-    runWithDelay 10 exec ./dev_run.sh init-bootstrappers &
+    sudo rm -rf workspaces/*
+    runWithDelay 10 exec ./workspace-upload.sh &
+    runWithDelay 15 exec ./dev_run.sh init-bootstrappers &
     touch .vbox_cluster_inited
 fi
 startBootstrapperMachines

--- a/dhcp/server.go
+++ b/dhcp/server.go
@@ -217,6 +217,12 @@ func (h *Handler) ServeDHCP(p dhcp4.Packet, msgType dhcp4.MessageType, options d
 					Value: h.fillPXE(),
 				},
 			)
+
+			// TODO: Use the one on api.go
+			hash, err := h.datasource.GetClusterVariable("CurrentWorkspaceHash")
+			if err == nil {
+				machineInterface.SetVariable("booted-workspace-hash", hash)
+			}
 		}
 		packet := dhcp4.ReplyPacket(p, responseMsgType, h.serverIP, machine.IP,
 			randLeaseDuration(), replyOptions)

--- a/web/server.go
+++ b/web/server.go
@@ -56,6 +56,8 @@ func (ws *webServer) Handler() http.Handler {
 
 	mux.PathPrefix("/static/").Handler(http.FileServer(FS(false)))
 
+	mux.PathPrefix("/uploadworkspace/{hash}").HandlerFunc(ws.WorkspaceUploadHandler).Methods("POST")
+
 	return mux
 }
 

--- a/web/static/partials/about.html
+++ b/web/static/partials/about.html
@@ -9,6 +9,7 @@
       <p class="lead">Commit: <code>{{ info.commit }}</code></p>
       <p class="lead">Build Time: <code>{{ info.buildTime }}</code></p>
       <p class="lead">IP: <code>{{ info.ip }}</code></p>
+      <p class="lead">Current workspace hash: <code>{{ info.currentWorkspaceHash }}</code></p>
       <p class="lead">Uptime: <em>{{ uptime() }}</em></p>
     </div>
   </div>

--- a/workspace-upload.sh
+++ b/workspace-upload.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
+
+IP=${1:-127.0.0.1}
+MD5=($(md5sum ../blacksmith-kubernetes/workspace/files/workspace.tar))
+
+curl -X POST -H "Content-Type: application/octet-stream" --data-binary '@../blacksmith-kubernetes/workspace/files/workspace.tar' http://127.0.0.1:8000/uploadworkspace/$MD5


### PR DESCRIPTION
This patch makes presence of workspace optional and provides an initial API for its upload.‌ It also adds current workspace hash to blacksmith's about page and stores the hash for each of the machines.
